### PR TITLE
Feat: Adding Bech32 Prefix Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# IDE folders & files
+.idea
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,10 @@ type matcher struct {
 }
 
 func (m matcher) Match(candidate string) bool {
-	candidate = strings.TrimPrefix(candidate, "cosmos1")
+	var builder strings.Builder
+	builder.WriteString(m.Prefix)
+	builder.WriteString("1") // build prefix string
+	candidate = strings.TrimPrefix(candidate, builder.String())
 	if !strings.HasPrefix(candidate, m.StartsWith) {
 		return false
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -7,9 +7,17 @@ import (
 )
 
 func TestGenerateWallet(t *testing.T) {
-	w := generateWallet()
+	w := generateWallet("cosmos")
 	require.Equal(t, w.Address[:7], "cosmos1", "Incorrect bech32 prefix")
 	require.Equal(t, len(w.Address), 45, "Incorrect privkey length")
+	require.Equal(t, len(w.Pubkey), 33, "Incorrect pubkey length")
+	require.Equal(t, len(w.Privkey), 32, "Incorrect privkey length")
+}
+
+func TestGenerateWalletWithPrefix(t *testing.T) {
+	w := generateWallet("osmo")
+	require.Equal(t, w.Address[:5], "osmo1", "Incorrect bech32 prefix")
+	require.Equal(t, len(w.Address), 43, "Incorrect privkey length")
 	require.Equal(t, len(w.Pubkey), 33, "Incorrect pubkey length")
 	require.Equal(t, len(w.Privkey), 32, "Incorrect privkey length")
 }


### PR DESCRIPTION
By default, the bech32 prefix is "cosmos", to support other chains, a bech32 prefix should be specified. Adding the flag `--prefix` or `-p` followed by the prefix will now generate addresses with the prefix specified. 

For example, for generating a vanity address on Jackal you would now run `cosmosvanity -p jkl`.